### PR TITLE
test-admin_tests

### DIFF
--- a/drain_eye/integration_test/pages/admin_page.dart
+++ b/drain_eye/integration_test/pages/admin_page.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'base_page.dart';
+
+/// PageObject для административной панели (AdminMainScreen)
+class AdminPage extends BasePage {
+  AdminPage(WidgetTester tester) : super(tester);
+
+  // Вкладки нижней навигации (BottomNavigationBar)
+  Finder get tabDashboard => find.text('Главная');
+  Finder get tabUsers => find.text('Пользователи');
+  Finder get tabInspections => find.text('Инспекции');
+  Finder get tabSettings => find.text('Настройки');
+
+  // Заголовки AppBar для каждой вкладки
+  Finder get appBarTitleDashboard => find.text('Панель управления');
+  Finder get appBarTitleUsers => find.text('Пользователи');
+  Finder get appBarTitleInspections => find.text('Инспекции');
+  Finder get appBarTitleSettings => find.text('Настройки');
+
+  // Кнопка выхода в AppBar
+  Finder get logoutAppBarButton => find.byIcon(Icons.logout);
+  Finder get logoutAppBarTooltip => find.byTooltip('Выйти');
+
+  // Якоря для вкладки "Главная"
+  Finder get dashboardSystemOverviewTitle => find.text('Обзор системы');
+  Finder get dashboardLastActionsTitle => find.text('Последние действия');
+
+  // Якоря для вкладки "Пользователи"
+  Finder get usersAllUsersTitle => find.text('Все пользователи');
+  Finder get adminRoleChip => find.text('Администратор');
+  Finder get adminEmailText => find.text('admin@draineye.com');
+
+  // Якоря для вкладки "Инспекции"
+  Finder get inspectionsAllTitle => find.text('Все инспекции');
+  Finder get inspectionsCountText => find.textContaining('записей'); // Например, "5 записей"
+  Finder get inspectionStatusOnReview => find.text('На проверке');
+  Finder get inspectionStatusDone => find.text('Завершена');
+  Finder get inspectionStatusRejected => find.text('Отклонена');
+
+  // Якоря для вкладки "Настройки"
+  Finder get settingsSectionSystem => find.text('Система');
+  Finder get settingsSectionNotifications => find.text('Уведомления');
+  Finder get settingsSectionSecurity => find.text('Безопасность');
+  Finder get logoutSettingsButton => find.text('Выйти из аккаунта');
+
+  // Действия
+  /// Переключение на "Главная"
+  Future<void> tapDashboardTab() async => tap(tabDashboard);
+
+  /// Переключение на "Пользователи"
+  Future<void> tapUsersTab() async => tap(tabUsers);
+
+  /// Переключение на "Инспекции"
+  Future<void> tapInspectionsTab() async => tap(tabInspections);
+
+  /// Переключение на "Настройки"
+  Future<void> tapSettingsTab() async => tap(tabSettings);
+
+  /// Выход из системы через кнопку в AppBar (Icons.logout)
+  Future<void> tapLogoutAppBar() async => tap(logoutAppBarButton);
+
+  /// Выход из системы через кнопку в настройках: "Выйти из аккаунта"
+  Future<void> tapLogoutSettings() async => tap(logoutSettingsButton);
+
+  /// Прокрутка вниp
+  Future<void> scrollDown({double offset = 400}) async {
+    await tester.fling(
+      find.byType(Scaffold),
+      Offset(0, -offset),
+      1200,
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// Прокрутка вверх
+  Future<void> scrollUp({double offset = 400}) async {
+    await tester.fling(
+      find.byType(Scaffold),
+      Offset(0, offset),
+      1200,
+    );
+    await tester.pumpAndSettle();
+  }
+
+  // Проверки видимости
+  /// Проверяет видимость всех элементов нижней навигации
+  Future<void> expectBottomNavVisible() async {
+    await expectVisible(tabDashboard);
+    await expectVisible(tabUsers);
+    await expectVisible(tabInspections);
+    await expectVisible(tabSettings);
+  }
+
+  /// Проверяет видимость "Главная"
+  Future<void> expectDashboardVisible() async {
+    await expectVisible(appBarTitleDashboard);
+    await expectVisible(dashboardSystemOverviewTitle);
+    await expectVisible(dashboardLastActionsTitle);
+  }
+
+  /// Проверяет видимость "Пользователи"
+  Future<void> expectUsersVisible() async {
+    await expectVisible(appBarTitleUsers);
+    await expectVisible(usersAllUsersTitle);
+  }
+
+  /// Проверяет видимость "Инспекции"
+  Future<void> expectInspectionsVisible() async {
+    await expectVisible(appBarTitleInspections);
+    await expectVisible(inspectionsAllTitle);
+    await expectVisible(inspectionsCountText);
+  }
+
+  /// Проверяет видимость "Настройки"
+  Future<void> expectSettingsVisible() async {
+    await expectVisible(appBarTitleSettings);
+    await expectVisible(settingsSectionSystem);
+    await expectVisible(settingsSectionNotifications);
+    await expectVisible(settingsSectionSecurity);
+    await expectVisible(logoutSettingsButton);
+  }
+
+  /// Проверяет видимость кнопки выхода в AppBar
+  Future<void> expectLogoutAppBarVisible() async {
+    await expectVisible(logoutAppBarButton);
+    await expectVisible(logoutAppBarTooltip);
+  }
+}

--- a/drain_eye/integration_test/smoke_tests/admin/admin_smoke_test.dart
+++ b/drain_eye/integration_test/smoke_tests/admin/admin_smoke_test.dart
@@ -1,0 +1,104 @@
+import 'package:drain_eye/presentation/screens/admin/admin_main_screen.dart';
+import 'package:drain_eye/presentation/screens/auth/login_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '../../pages/admin_page.dart';
+
+/// Интеграционные дымовые тесты административной панели
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Smoke тесты для AdminMainScreen', () {
+    Future<void> pumpAdminApp(WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          debugShowCheckedModeBanner: false,
+          home: AdminMainScreen(),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('Smoke: отображается панель управления и нижняя навигация', (tester) async {
+      await pumpAdminApp(tester);
+
+      final adminPage = AdminPage(tester);
+
+      await adminPage.expectBottomNavVisible();
+      await adminPage.expectLogoutAppBarVisible();
+      await adminPage.expectDashboardVisible();
+    });
+
+    testWidgets('Навигация: переключение вкладок и проверка якорей', (tester) async {
+      await pumpAdminApp(tester);
+
+      final adminPage = AdminPage(tester);
+
+      // Пользователи
+      await adminPage.tapUsersTab();
+      await adminPage.expectUsersVisible();
+
+      // Инспекции
+      await adminPage.tapInspectionsTab();
+      await adminPage.expectInspectionsVisible();
+
+      // Настройки
+      await adminPage.tapSettingsTab();
+      await adminPage.expectSettingsVisible();
+
+      // Панель управления
+      await adminPage.tapDashboardTab();
+      await adminPage.expectDashboardVisible();
+    });
+
+    testWidgets('Прокрутка: просмотр панели управления', (tester) async {
+      await pumpAdminApp(tester);
+
+      final adminPage = AdminPage(tester);
+
+      await adminPage.expectDashboardVisible();
+      await adminPage.scrollDown();
+      await adminPage.scrollUp();
+
+      expect(adminPage.dashboardSystemOverviewTitle, findsOneWidget);
+    });
+
+    testWidgets('Выход: кнопка выхода в AppBar перенаправляет на LoginScreen', (tester) async {
+      await pumpAdminApp(tester);
+
+      final adminPage = AdminPage(tester);
+
+      await adminPage.expectLogoutAppBarVisible();
+      await adminPage.tapLogoutAppBar();
+
+      expect(find.byType(LoginScreen), findsOneWidget);
+
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LoginScreen), findsOneWidget);
+      expect(find.byType(AdminMainScreen), findsNothing);
+    });
+
+    testWidgets('Выход: кнопка выхода в настройках перенаправляет на LoginScreen', (tester) async {
+      await pumpAdminApp(tester);
+
+      final adminPage = AdminPage(tester);
+
+      await adminPage.tapSettingsTab();
+      await adminPage.expectSettingsVisible();
+
+      await adminPage.tapLogoutSettings();
+
+      expect(find.byType(LoginScreen), findsOneWidget);
+
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LoginScreen), findsOneWidget);
+      expect(find.byType(AdminMainScreen), findsNothing);
+    });
+  });
+}

--- a/drain_eye/test/admin_main_screen_test.dart
+++ b/drain_eye/test/admin_main_screen_test.dart
@@ -1,0 +1,78 @@
+import 'package:drain_eye/presentation/screens/admin/admin_main_screen.dart';
+import 'package:drain_eye/presentation/screens/auth/login_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: child);
+
+void main() {
+  group('AdminMainScreen', () {
+    testWidgets('Отображает панель управления при запуске по умолчанию', (tester) async {
+      await tester.pumpWidget(_wrap(const AdminMainScreen()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Панель управления'), findsOneWidget);
+
+      expect(find.text('Обзор системы'), findsOneWidget);
+      expect(find.text('Последние действия'), findsOneWidget);
+
+      expect(find.text('Главная'), findsOneWidget);
+      expect(find.text('Пользователи'), findsOneWidget);
+      expect(find.text('Инспекции'), findsOneWidget);
+      expect(find.text('Настройки'), findsOneWidget);
+    });
+
+    testWidgets('Переключает вкладки и обновляет заголовок AppBar', (tester) async {
+      await tester.pumpWidget(_wrap(const AdminMainScreen()));
+      await tester.pumpAndSettle();
+
+      // Вкладка "Пользователи"
+      await tester.tap(find.text('Пользователи'));
+      await tester.pumpAndSettle();
+      expect(find.text('Пользователи'), findsOneWidget);
+      expect(find.text('Все пользователи'), findsOneWidget);
+
+      // Вкладка "Инспекции"
+      await tester.tap(find.text('Инспекции'));
+      await tester.pumpAndSettle();
+      expect(find.text('Инспекции'), findsOneWidget);
+      expect(find.text('Все инспекции'), findsOneWidget);
+      expect(find.textContaining('записей'), findsOneWidget); // Например, "5 записей"
+
+      // Вкладка "Настройки"
+      await tester.tap(find.text('Настройки'));
+      await tester.pumpAndSettle();
+      expect(find.text('Настройки'), findsOneWidget);
+      expect(find.text('Система'), findsOneWidget);
+      expect(find.text('Уведомления'), findsOneWidget);
+      expect(find.text('Безопасность'), findsOneWidget);
+      expect(find.text('Выйти из аккаунта'), findsOneWidget);
+    });
+
+    testWidgets('Выход из системы через иконку в AppBar перенаправляет на экран входа', (tester) async {
+      await tester.pumpWidget(_wrap(const AdminMainScreen()));
+      await tester.pumpAndSettle();
+
+      // Нажатие на иконку выхода в AppBar
+      await tester.tap(find.byIcon(Icons.logout));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LoginScreen), findsOneWidget);
+    });
+
+    testWidgets('Выход из системы через кнопку в настройках перенаправляет на экран входа', (tester) async {
+      await tester.pumpWidget(_wrap(const AdminMainScreen()));
+      await tester.pumpAndSettle();
+
+      // Открытие вкладки "Настройки"
+      await tester.tap(find.text('Настройки'));
+      await tester.pumpAndSettle();
+
+      // Нажатие на кнопку "Выйти из аккаунта"
+      await tester.tap(find.text('Выйти из аккаунта'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LoginScreen), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
### Тесты для административной части приложения (AdminMainScreen)

- `drain_eye/integration_test/pages/admin_page.dart`  (PageObject для административной части)

- `drain_eye/integration_test/smoke_tests/admin/admin_smoke_test.dart`  (интеграционные smoke‑тесты) 
  - корректный запуск и отрисовка;
  - переключение вкладок через `BottomNavigationBar` с проверкой якорных элементов;
  - проверка прокрутки;
  - сценарии выхода через AppBar и кнопку в настройках;
  - проверка корректности навигации через `pushReplacement`

- `drain_eye/test/admin_main_screen_test.dart`  
  Добавлены widget‑тесты для `AdminMainScreen` (проверка рендера, переключения вкладок и выхода на `LoginScreen`)