### PR TITLE
feat(admin): add dashboard with recent inspections and fix users endp…

### DIFF
--- a/drain_eye/lib/core/api_config.dart
+++ b/drain_eye/lib/core/api_config.dart
@@ -1,0 +1,5 @@
+// Базовый URL сервера. Меняется при каждом запуске tuna.am — обновлять здесь.
+// Должен совпадать с baseUrl в auth_repository_impl.dart.
+class ApiConfig {
+  static const String baseUrl = 'https://abvvse-95-161-60-178.ru.tuna.am';
+}

--- a/drain_eye/lib/core/token_storage.dart
+++ b/drain_eye/lib/core/token_storage.dart
@@ -1,0 +1,12 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+// Чтение JWT-токена из SharedPreferences.
+// Ключ совпадает с тем, что использует AuthRepositoryImpl при сохранении.
+class TokenStorage {
+  static const _keyToken = 'auth_token';
+
+  static Future<String?> getToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_keyToken);
+  }
+}

--- a/drain_eye/lib/data/datasources/admin_remote_datasource.dart
+++ b/drain_eye/lib/data/datasources/admin_remote_datasource.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+import 'package:drain_eye/core/api_config.dart';
+import 'package:drain_eye/core/token_storage.dart';
+import 'package:drain_eye/domain/entities/admin_inspection.dart';
+import 'package:drain_eye/domain/entities/admin_user.dart';
+import 'package:http/http.dart' as http;
+
+class AdminRemoteDataSource {
+  final http.Client _client;
+
+  AdminRemoteDataSource({http.Client? client}) : _client = client ?? http.Client();
+
+  Future<PaginatedResponse<AdminUser>> getUsers({
+    String role = 'inspector',
+    int limit = 50,
+    String? nextCursor,
+    bool activeOnly = true,
+  }) async {
+    final query = <String, String>{
+      'role': role,
+      'limit': '$limit',
+      'active_only': '$activeOnly',
+    };
+    if (nextCursor != null) query['next_cursor'] = nextCursor;
+
+    final uri = Uri.parse('${ApiConfig.baseUrl}/admin/users/by-role').replace(queryParameters: query);
+    final response = await _client.get(uri, headers: await _headers());
+    _checkStatus(response);
+
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    final users = (body['users'] as List)
+        .map((e) => AdminUser.fromJson(e as Map<String, dynamic>))
+        .toList();
+
+    return PaginatedResponse<AdminUser>(
+      items: users,
+      nextCursor: body['next_cursor'] as String?,
+      hasMore: body['has_more'] as bool? ?? false,
+      totalReturned: (body['total_returned'] as num?)?.toInt() ?? users.length,
+    );
+  }
+
+  Future<PaginatedResponse<AdminInspection>> getInspections({
+    int limit = 50,
+    String? nextCursor,
+  }) async {
+    final query = <String, String>{'limit': '$limit'};
+    if (nextCursor != null) query['next_cursor'] = nextCursor;
+
+    final uri = Uri.parse('${ApiConfig.baseUrl}/admin/inspections').replace(queryParameters: query);
+    final response = await _client.get(uri, headers: await _headers());
+    _checkStatus(response);
+
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    final inspections = (body['inspections'] as List)
+        .map((e) => AdminInspection.fromJson(e as Map<String, dynamic>))
+        .toList();
+
+    return PaginatedResponse<AdminInspection>(
+      items: inspections,
+      nextCursor: body['next_cursor'] as String?,
+      hasMore: body['has_more'] as bool? ?? false,
+      totalReturned: (body['total_returned'] as num?)?.toInt() ?? inspections.length,
+    );
+  }
+
+  Future<DashboardMetrics> getDashboardMetrics() async {
+    final uri = Uri.parse('${ApiConfig.baseUrl}/admin/metrics/dashboard');
+    final response = await _client.get(uri, headers: await _headers());
+    _checkStatus(response);
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    return DashboardMetrics.fromJson(body);
+  }
+
+  Future<Map<String, String>> _headers() async {
+    final token = await TokenStorage.getToken();
+    return {
+      'Accept': 'application/json',
+      'tuna-skip-browser-warning': 'true',
+      if (token != null) 'Authorization': 'Bearer $token',
+    };
+  }
+
+  void _checkStatus(http.Response response) {
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      throw AdminException('Нет доступа: войдите как администратор');
+    }
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw AdminException('Ошибка сервера: ${response.statusCode}');
+    }
+  }
+}
+
+class AdminException implements Exception {
+  final String message;
+  const AdminException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/drain_eye/lib/data/repositories_impl/auth_repository_impl.dart
+++ b/drain_eye/lib/data/repositories_impl/auth_repository_impl.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:drain_eye/core/api_config.dart';
 import 'package:drain_eye/domain/entities/user.dart';
 import 'package:drain_eye/domain/repositories/auth_repository.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
@@ -24,9 +25,6 @@ class AuthRepositoryImpl implements AuthRepository {
   final firebase_auth.FirebaseAuth? _firebaseAuth;
   Future<void>? _googleSignInInitialized;
 
-  // базовый URL бэкенда (можно позже заменить на реальный)
-  final String baseUrl = 'https://2pw8ay-95-161-60-178.ru.tuna.am';
-
   static const _userPrefsKey = 'user';
   static const _authTokenPrefsKey = 'auth_token';
 
@@ -43,7 +41,7 @@ class AuthRepositoryImpl implements AuthRepository {
       throw Exception('введите имя');
     }
 
-    final uri = Uri.parse('$baseUrl/inspector/register');
+    final uri = Uri.parse('${ApiConfig.baseUrl}/admin/register');
     if (kDebugMode) {
       print('Register backend request: $uri email=$normalizedEmail');
     }
@@ -52,6 +50,7 @@ class AuthRepositoryImpl implements AuthRepository {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
+        'tuna-skip-browser-warning': 'true',
       },
       body: jsonEncode({
         'email': normalizedEmail,
@@ -301,10 +300,11 @@ class AuthRepositoryImpl implements AuthRepository {
     required bool signOutOnBackendError,
   }) async {
     final response = await _httpClient.post(
-      Uri.parse('$baseUrl/inspector/login'),
+      Uri.parse('${ApiConfig.baseUrl}/admin/login'),
       headers: {
         'Accept': 'application/json',
         'Authorization': 'Bearer $token',
+        'tuna-skip-browser-warning': 'true',
       },
     );
 

--- a/drain_eye/lib/domain/entities/admin_inspection.dart
+++ b/drain_eye/lib/domain/entities/admin_inspection.dart
@@ -1,0 +1,74 @@
+import 'package:drain_eye/domain/entities/admin_user.dart';
+
+// Сущность инспекции для админ-панели (InspectionResponse с бэкенда).
+class AdminInspection {
+  final String id;
+  final String engineerId;
+  final DateTime timestamp;
+  final String address;
+  final String name;
+  final String statusSync;
+  final EngineerBrief? engineer;
+
+  const AdminInspection({
+    required this.id,
+    required this.engineerId,
+    required this.timestamp,
+    required this.address,
+    required this.name,
+    required this.statusSync,
+    this.engineer,
+  });
+
+  factory AdminInspection.fromJson(Map<String, dynamic> json) {
+    return AdminInspection(
+      id: json['id'] as String,
+      engineerId: json['engineer_id'] as String,
+      timestamp: DateTime.parse(json['timestamp'] as String),
+      address: json['address'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      statusSync: json['status_sync'] as String? ?? 'pending',
+      engineer: json['engineer'] != null
+          ? EngineerBrief.fromJson(json['engineer'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+class DashboardMetrics {
+  final int totalInspectors;
+  final int totalInspections;
+  final int todayCount;
+  final int pendingCount;
+
+  const DashboardMetrics({
+    required this.totalInspectors,
+    required this.totalInspections,
+    required this.todayCount,
+    required this.pendingCount,
+  });
+
+  factory DashboardMetrics.fromJson(Map<String, dynamic> json) {
+    return DashboardMetrics(
+      totalInspectors: (json['active_inspectors'] as num?)?.toInt() ?? 0,
+      totalInspections: (json['total_inspections'] as num?)?.toInt() ?? 0,
+      todayCount: (json['inspections_today'] as num?)?.toInt() ?? 0,
+      pendingCount: 0,
+    );
+  }
+}
+
+// Ответ с пагинацией.
+class PaginatedResponse<T> {
+  final List<T> items;
+  final String? nextCursor;
+  final bool hasMore;
+  final int totalReturned;
+
+  const PaginatedResponse({
+    required this.items,
+    required this.nextCursor,
+    required this.hasMore,
+    required this.totalReturned,
+  });
+}

--- a/drain_eye/lib/domain/entities/admin_user.dart
+++ b/drain_eye/lib/domain/entities/admin_user.dart
@@ -1,0 +1,60 @@
+// Сущность пользователя для админ-панели (UserResponse с бэкенда).
+class AdminUser {
+  final String userId;
+  final String email;
+  final String fullName;
+  final String role;
+  final bool isActive;
+  final int countInspections;
+  final DateTime? lastActivity;
+  final DateTime? createdAt;
+
+  const AdminUser({
+    required this.userId,
+    required this.email,
+    required this.fullName,
+    required this.role,
+    required this.isActive,
+    required this.countInspections,
+    this.lastActivity,
+    this.createdAt,
+  });
+
+  factory AdminUser.fromJson(Map<String, dynamic> json) {
+    return AdminUser(
+      userId: json['user_id'] as String,
+      email: json['email'] as String,
+      fullName: json['full_name'] as String,
+      role: json['role'] as String,
+      isActive: json['is_active'] as bool,
+      countInspections: (json['count_inspections'] as num?)?.toInt() ?? 0,
+      lastActivity: json['last_activity'] != null
+          ? DateTime.tryParse(json['last_activity'] as String)
+          : null,
+      createdAt: json['created_at'] != null
+          ? DateTime.tryParse(json['created_at'] as String)
+          : null,
+    );
+  }
+}
+
+// Краткие данные инженера, прикреплённые к инспекции.
+class EngineerBrief {
+  final String userId;
+  final String fullName;
+  final String email;
+
+  const EngineerBrief({
+    required this.userId,
+    required this.fullName,
+    required this.email,
+  });
+
+  factory EngineerBrief.fromJson(Map<String, dynamic> json) {
+    return EngineerBrief(
+      userId: json['user_id'] as String,
+      fullName: json['full_name'] as String,
+      email: json['email'] as String,
+    );
+  }
+}

--- a/drain_eye/lib/presentation/screens/admin/admin_main_screen.dart
+++ b/drain_eye/lib/presentation/screens/admin/admin_main_screen.dart
@@ -1,9 +1,13 @@
+import 'package:drain_eye/data/datasources/admin_remote_datasource.dart';
+import 'package:drain_eye/domain/entities/admin_inspection.dart';
+import 'package:drain_eye/domain/entities/admin_user.dart';
 import 'package:drain_eye/presentation/screens/auth/login_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 const _teal = Color(0xFF0D9488);
 
-/// Главный экран администратора — заглушка панели управления.
+/// Главный экран администратора.
 class AdminMainScreen extends StatefulWidget {
   const AdminMainScreen({super.key});
 
@@ -13,6 +17,133 @@ class AdminMainScreen extends StatefulWidget {
 
 class _AdminMainScreenState extends State<AdminMainScreen> {
   int _selectedIndex = 0;
+  final _ds = AdminRemoteDataSource();
+
+  // Состояние дашборда
+  DashboardMetrics? _metrics;
+  bool _metricsLoading = false;
+  String? _metricsError;
+
+  // Состояние списка пользователей
+  final List<AdminUser> _users = [];
+  String? _usersNextCursor;
+  bool _usersHasMore = true;
+  bool _usersLoading = false;
+  bool _usersInitialLoaded = false;
+  String? _usersError;
+
+  // Состояние списка инспекций
+  final List<AdminInspection> _inspections = [];
+  String? _inspectionsNextCursor;
+  bool _inspectionsHasMore = true;
+  bool _inspectionsLoading = false;
+  bool _inspectionsInitialLoaded = false;
+  String? _inspectionsError;
+
+  // Последние инспекции на главной (фиксированное число записей)
+  static const int _recentInspectionsLimit = 4;
+  List<AdminInspection> _recentInspections = const [];
+  bool _recentLoading = false;
+  String? _recentError;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMetrics();
+    _loadRecentInspections();
+  }
+
+  Future<void> _loadMetrics() async {
+    setState(() { _metricsLoading = true; _metricsError = null; });
+    try {
+      final result = await _ds.getDashboardMetrics();
+      if (mounted) setState(() => _metrics = result);
+    } on AdminException catch (e) {
+      if (mounted) setState(() => _metricsError = e.message);
+    } catch (_) {
+      if (mounted) setState(() => _metricsError = 'Нет соединения с сервером');
+    } finally {
+      if (mounted) setState(() => _metricsLoading = false);
+    }
+  }
+
+  Future<void> _loadRecentInspections() async {
+    setState(() { _recentLoading = true; _recentError = null; });
+    try {
+      final result = await _ds.getInspections(limit: _recentInspectionsLimit);
+      if (mounted) setState(() => _recentInspections = result.items);
+    } on AdminException catch (e) {
+      if (mounted) setState(() => _recentError = e.message);
+    } catch (_) {
+      if (mounted) setState(() => _recentError = 'Нет соединения с сервером');
+    } finally {
+      if (mounted) setState(() => _recentLoading = false);
+    }
+  }
+
+  void _onTabTapped(int index) {
+    setState(() => _selectedIndex = index);
+    if (index == 1 && !_usersInitialLoaded) _loadUsers();
+    if (index == 2 && !_inspectionsInitialLoaded) _loadInspections();
+  }
+
+  Future<void> _loadUsers({bool reset = false}) async {
+    if (_usersLoading) return;
+    setState(() {
+      _usersLoading = true;
+      _usersError = null;
+      if (reset) {
+        _users.clear();
+        _usersNextCursor = null;
+        _usersHasMore = true;
+      }
+    });
+    try {
+      final result = await _ds.getUsers(nextCursor: _usersNextCursor);
+      if (!mounted) return;
+      setState(() {
+        _users.addAll(result.items);
+        _usersNextCursor = result.nextCursor;
+        _usersHasMore = result.hasMore;
+        _usersInitialLoaded = true;
+      });
+    } on AdminException catch (e) {
+      if (mounted) setState(() => _usersError = e.message);
+    } catch (_) {
+      if (mounted) setState(() => _usersError = 'Нет соединения с сервером');
+    } finally {
+      if (mounted) setState(() => _usersLoading = false);
+    }
+  }
+
+  Future<void> _loadInspections({bool reset = false}) async {
+    if (_inspectionsLoading) return;
+    setState(() {
+      _inspectionsLoading = true;
+      _inspectionsError = null;
+      if (reset) {
+        _inspections.clear();
+        _inspectionsNextCursor = null;
+        _inspectionsHasMore = true;
+      }
+    });
+    try {
+      final result = await _ds.getInspections(nextCursor: _inspectionsNextCursor);
+      if (!mounted) return;
+      setState(() {
+        _inspections.addAll(result.items);
+        _inspectionsNextCursor = result.nextCursor;
+        _inspectionsHasMore = result.hasMore;
+        _inspectionsInitialLoaded = true;
+      });
+    } on AdminException catch (e) {
+      if (mounted) setState(() => _inspectionsError = e.message);
+    } catch (_) {
+      if (mounted) setState(() => _inspectionsError = 'Нет соединения с сервером');
+    } finally {
+      if (mounted) setState(() => _inspectionsLoading = false);
+    }
+  }
 
   String _getAppBarTitle() {
     switch (_selectedIndex) {
@@ -43,11 +174,7 @@ class _AdminMainScreenState extends State<AdminMainScreen> {
             Text(_getAppBarTitle()),
           ],
         ),
-        titleTextStyle: const TextStyle(
-          fontWeight: FontWeight.bold,
-          fontSize: 20,
-          color: Colors.white,
-        ),
+        titleTextStyle: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20, color: Colors.white),
         toolbarHeight: 56,
         backgroundColor: _teal,
         foregroundColor: Colors.white,
@@ -57,10 +184,7 @@ class _AdminMainScreenState extends State<AdminMainScreen> {
             icon: const Icon(Icons.logout),
             tooltip: 'Выйти',
             onPressed: () {
-              Navigator.pushReplacement(
-                context,
-                MaterialPageRoute(builder: (_) => const LoginScreen()),
-              );
+              Navigator.pushReplacement(context, MaterialPageRoute(builder: (_) => const LoginScreen()));
             },
           ),
         ],
@@ -72,24 +196,12 @@ class _AdminMainScreenState extends State<AdminMainScreen> {
         ),
         child: BottomNavigationBar(
           currentIndex: _selectedIndex,
-          onTap: (index) => setState(() => _selectedIndex = index),
+          onTap: _onTabTapped,
           items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.dashboard),
-              label: 'Главная',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.people),
-              label: 'Пользователи',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.assignment),
-              label: 'Инспекции',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.settings),
-              label: 'Настройки',
-            ),
+            BottomNavigationBarItem(icon: Icon(Icons.dashboard), label: 'Главная'),
+            BottomNavigationBarItem(icon: Icon(Icons.people), label: 'Пользователи'),
+            BottomNavigationBarItem(icon: Icon(Icons.assignment), label: 'Инспекции'),
+            BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Настройки'),
           ],
           selectedItemColor: _teal,
           unselectedItemColor: const Color(0xFF94A3B8),
@@ -118,47 +230,156 @@ class _AdminMainScreenState extends State<AdminMainScreen> {
     }
   }
 
-  // --- Вкладка: Панель управления ---
   Widget _buildDashboard() {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+    if (_metricsLoading) {
+      return const Center(child: CircularProgressIndicator(color: _teal));
+    }
+    if (_metricsError != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_metricsError!, style: const TextStyle(color: Colors.red)),
+            const SizedBox(height: 12),
+            TextButton(onPressed: _loadMetrics, child: const Text('Повторить')),
+          ],
+        ),
+      );
+    }
+    final m = _metrics;
+    return RefreshIndicator(
+      color: _teal,
+      onRefresh: () async {
+        await Future.wait([_loadMetrics(), _loadRecentInspections()]);
+      },
+      child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Обзор системы', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700, color: Color(0xFF334155))),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(child: _statCard('Инспекторов', '${m?.totalInspectors ?? 0}', Icons.person, const Color(0xFF3B82F6))),
+                const SizedBox(width: 12),
+                Expanded(child: _statCard('Инспекций', '${m?.totalInspections ?? 0}', Icons.assignment, _teal)),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(child: _statCard('За сегодня', '${m?.todayCount ?? 0}', Icons.today, const Color(0xFFF59E0B))),
+                const SizedBox(width: 12),
+                const Expanded(child: SizedBox.shrink()),
+              ],
+            ),
+            const SizedBox(height: 24),
+            const Text('Последние инспекции', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700, color: Color(0xFF334155))),
+            const SizedBox(height: 12),
+            _buildRecentInspections(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRecentInspections() {
+    if (_recentLoading && _recentInspections.isEmpty) {
+      return Container(
+        height: 220,
+        alignment: Alignment.center,
+        child: const CircularProgressIndicator(color: _teal),
+      );
+    }
+    if (_recentError != null && _recentInspections.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.03), blurRadius: 4, offset: const Offset(0, 1))],
+        ),
+        child: Column(
+          children: [
+            Text(_recentError!, style: const TextStyle(fontSize: 13, color: Color(0xFFEF4444))),
+            const SizedBox(height: 8),
+            OutlinedButton(onPressed: _loadRecentInspections, child: const Text('Повторить')),
+          ],
+        ),
+      );
+    }
+    if (_recentInspections.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.symmetric(vertical: 24),
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.03), blurRadius: 4, offset: const Offset(0, 1))],
+        ),
+        child: const Text('Пока нет инспекций', style: TextStyle(fontSize: 13, color: Color(0xFF94A3B8))),
+      );
+    }
+    return Column(
+      children: [
+        for (final i in _recentInspections) _recentInspectionCard(i),
+      ],
+    );
+  }
+
+  Widget _recentInspectionCard(AdminInspection i) {
+    final fullName = i.engineer?.fullName ?? '—';
+    final inspectorShort = _shortName(fullName);
+    final initial = fullName.trim().isNotEmpty ? fullName.trim()[0].toUpperCase() : '?';
+    final shortId = '#${i.id.length > 6 ? i.id.substring(i.id.length - 6) : i.id}';
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(10),
+        boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.03), blurRadius: 4, offset: const Offset(0, 1))],
+      ),
+      child: Row(
         children: [
-          const Text(
-            'Обзор системы',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700, color: Color(0xFF334155)),
+          CircleAvatar(
+            radius: 18,
+            backgroundColor: _teal.withOpacity(0.1),
+            child: Text(initial, style: const TextStyle(color: _teal, fontWeight: FontWeight.w600, fontSize: 13)),
           ),
-          const SizedBox(height: 16),
-          // статистика — карточки
-          Row(
-            children: [
-              Expanded(child: _statCard('Инспекторов', '12', Icons.person, const Color(0xFF3B82F6))),
-              const SizedBox(width: 12),
-              Expanded(child: _statCard('Инспекций', '148', Icons.assignment, _teal)),
-            ],
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(inspectorShort, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: Color(0xFF334155))),
+                const SizedBox(height: 2),
+                Text('Новая инспекция $shortId', style: const TextStyle(fontSize: 12, color: Color(0xFF64748B))),
+              ],
+            ),
           ),
-          const SizedBox(height: 12),
-          Row(
-            children: [
-              Expanded(child: _statCard('За сегодня', '5', Icons.today, const Color(0xFFF59E0B))),
-              const SizedBox(width: 12),
-              Expanded(child: _statCard('На проверке', '3', Icons.pending_actions, const Color(0xFFEF4444))),
-            ],
-          ),
-          const SizedBox(height: 24),
-          const Text(
-            'Последние действия',
-            style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: Color(0xFF334155)),
-          ),
-          const SizedBox(height: 12),
-          _activityItem('Иванов А.П.', 'Новая инспекция #147', '10 мин назад'),
-          _activityItem('Петров С.К.', 'Загрузил фото к инспекции #145', '25 мин назад'),
-          _activityItem('Сидоров Д.В.', 'Завершил инспекцию #143', '1 час назад'),
-          _activityItem('Козлова М.А.', 'Зарегистрировалась в системе', '2 часа назад'),
+          const SizedBox(width: 8),
+          Text(_relativeTime(i.timestamp), style: const TextStyle(fontSize: 11, color: Color(0xFF94A3B8))),
         ],
       ),
     );
+  }
+
+  String _relativeTime(DateTime ts) {
+    final diff = DateTime.now().difference(ts);
+    if (diff.inSeconds < 60) return 'только что';
+    if (diff.inMinutes < 60) return '${diff.inMinutes} мин назад';
+    if (diff.inHours < 24) {
+      final h = diff.inHours;
+      return '$h ${h == 1 ? 'час' : (h < 5 ? 'часа' : 'часов')} назад';
+    }
+    if (diff.inDays < 7) {
+      final d = diff.inDays;
+      return '$d ${d == 1 ? 'день' : (d < 5 ? 'дня' : 'дней')} назад';
+    }
+    return DateFormat('dd.MM.yyyy').format(ts);
   }
 
   Widget _statCard(String label, String value, IconData icon, Color color) {
@@ -175,10 +396,7 @@ class _AdminMainScreenState extends State<AdminMainScreen> {
           Container(
             width: 36,
             height: 36,
-            decoration: BoxDecoration(
-              color: color.withOpacity(0.1),
-              borderRadius: BorderRadius.circular(8),
-            ),
+            decoration: BoxDecoration(color: color.withOpacity(0.1), borderRadius: BorderRadius.circular(8)),
             child: Icon(icon, color: color, size: 20),
           ),
           const SizedBox(height: 10),
@@ -190,7 +408,43 @@ class _AdminMainScreenState extends State<AdminMainScreen> {
     );
   }
 
-  Widget _activityItem(String user, String action, String time) {
+
+  // --- Вкладка: Пользователи ---
+  Widget _buildUsersTab() {
+    if (!_usersInitialLoaded && _usersLoading) {
+      return const Center(child: CircularProgressIndicator(color: _teal));
+    }
+    if (_usersError != null && _users.isEmpty) {
+      return _errorView(_usersError!, () => _loadUsers(reset: true));
+    }
+    return RefreshIndicator(
+      color: _teal,
+      onRefresh: () => _loadUsers(reset: true),
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        itemCount: _users.length + 2,
+        itemBuilder: (context, index) {
+          if (index == 0) {
+            return const Padding(
+              padding: EdgeInsets.only(bottom: 12),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text('Все пользователи', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: Color(0xFF334155))),
+              ),
+            );
+          }
+          if (index == _users.length + 1) {
+            return _buildLoadMore(_usersHasMore, _usersLoading, _usersError, () => _loadUsers());
+          }
+          return _userCard(_users[index - 1]);
+        },
+      ),
+    );
+  }
+
+  Widget _userCard(AdminUser u) {
+    final isAdmin = u.role.toLowerCase() == 'admin' || u.role == 'Администратор';
+    final initials = u.fullName.split(' ').where((w) => w.isNotEmpty).take(2).map((w) => w[0]).join();
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
@@ -202,202 +456,215 @@ class _AdminMainScreenState extends State<AdminMainScreen> {
       child: Row(
         children: [
           CircleAvatar(
-            radius: 18,
+            radius: 20,
             backgroundColor: _teal.withOpacity(0.1),
-            child: Text(
-              user.split(' ').first[0],
-              style: const TextStyle(color: _teal, fontWeight: FontWeight.w600, fontSize: 14),
-            ),
+            child: Text(initials, style: const TextStyle(color: _teal, fontWeight: FontWeight.w600, fontSize: 13)),
           ),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(user, style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600, color: Color(0xFF334155))),
+                Text(u.fullName, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: Color(0xFF334155))),
                 const SizedBox(height: 2),
-                Text(action, style: const TextStyle(fontSize: 12, color: Color(0xFF64748B))),
+                Text(u.email, style: const TextStyle(fontSize: 12, color: Color(0xFF64748B))),
               ],
             ),
           ),
-          Text(time, style: const TextStyle(fontSize: 11, color: Color(0xFF94A3B8))),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                decoration: BoxDecoration(
+                  color: isAdmin ? const Color(0xFFEDE9FE) : const Color(0xFFF0FDFA),
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Text(
+                  isAdmin ? 'Администратор' : 'Инспектор',
+                  style: TextStyle(fontSize: 11, fontWeight: FontWeight.w500, color: isAdmin ? const Color(0xFF7C3AED) : _teal),
+                ),
+              ),
+              const SizedBox(height: 4),
+              Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: u.isActive ? const Color(0xFF22C55E) : const Color(0xFF94A3B8),
+                ),
+              ),
+            ],
+          ),
         ],
       ),
     );
   }
 
-  // --- Вкладка: Пользователи ---
-  Widget _buildUsersTab() {
-    final users = [
-      _UserRow('Иванов Алексей Петрович', 'ivanov@mail.com', 'Инспектор', true),
-      _UserRow('Петров Сергей Константинович', 'petrov@mail.com', 'Инспектор', true),
-      _UserRow('Сидоров Дмитрий Владимирович', 'sidorov@mail.com', 'Инспектор', false),
-      _UserRow('Козлова Мария Андреевна', 'kozlova@mail.com', 'Инспектор', true),
-      _UserRow('Админов Павел Игоревич', 'admin@draineye.com', 'Администратор', true),
-    ];
-
-    return Column(
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-          child: const Align(
-            alignment: Alignment.centerLeft,
-            child: Text('Все пользователи', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: Color(0xFF334155))),
-          ),
-        ),
-        Expanded(
-          child: ListView.builder(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            itemCount: users.length,
-            itemBuilder: (context, index) {
-              final u = users[index];
-              return Container(
-                margin: const EdgeInsets.only(bottom: 8),
-                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(10),
-                  boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.03), blurRadius: 4, offset: const Offset(0, 1))],
-                ),
-                child: Row(
-                  children: [
-                    CircleAvatar(
-                      radius: 20,
-                      backgroundColor: _teal.withOpacity(0.1),
-                      child: Text(
-                        u.name.split(' ').map((w) => w[0]).take(2).join(),
-                        style: const TextStyle(color: _teal, fontWeight: FontWeight.w600, fontSize: 13),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(u.name, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: Color(0xFF334155))),
-                          const SizedBox(height: 2),
-                          Text(u.email, style: const TextStyle(fontSize: 12, color: Color(0xFF64748B))),
-                        ],
-                      ),
-                    ),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: [
-                        Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-                          decoration: BoxDecoration(
-                            color: u.role == 'Администратор' ? const Color(0xFFEDE9FE) : const Color(0xFFF0FDFA),
-                            borderRadius: BorderRadius.circular(6),
-                          ),
-                          child: Text(
-                            u.role,
-                            style: TextStyle(
-                              fontSize: 11,
-                              fontWeight: FontWeight.w500,
-                              color: u.role == 'Администратор' ? const Color(0xFF7C3AED) : _teal,
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 4),
-                        Container(
-                          width: 8,
-                          height: 8,
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: u.active ? const Color(0xFF22C55E) : const Color(0xFF94A3B8),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
-        ),
-      ],
+  // --- Вкладка: Инспекции ---
+  Widget _buildInspectionsTab() {
+    if (!_inspectionsInitialLoaded && _inspectionsLoading) {
+      return const Center(child: CircularProgressIndicator(color: _teal));
+    }
+    if (_inspectionsError != null && _inspections.isEmpty) {
+      return _errorView(_inspectionsError!, () => _loadInspections(reset: true));
+    }
+    return RefreshIndicator(
+      color: _teal,
+      onRefresh: () => _loadInspections(reset: true),
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        itemCount: _inspections.length + 2,
+        itemBuilder: (context, index) {
+          if (index == 0) {
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Row(
+                children: [
+                  const Text('Все инспекции', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: Color(0xFF334155))),
+                  const Spacer(),
+                  Text('${_inspections.length} записей', style: const TextStyle(fontSize: 12, color: Color(0xFF94A3B8))),
+                ],
+              ),
+            );
+          }
+          if (index == _inspections.length + 1) {
+            return _buildLoadMore(_inspectionsHasMore, _inspectionsLoading, _inspectionsError, () => _loadInspections());
+          }
+          return _inspectionCard(_inspections[index - 1]);
+        },
+      ),
     );
   }
 
-  // --- Вкладка: Инспекции ---
-  Widget _buildInspectionsTab() {
-    final inspections = [
-      _InspectionRow('#147', 'Иванов А.П.', 'ул. Ленина, 12', 'На проверке', const Color(0xFFF59E0B)),
-      _InspectionRow('#146', 'Петров С.К.', 'пр. Мира, 45', 'Завершена', const Color(0xFF22C55E)),
-      _InspectionRow('#145', 'Петров С.К.', 'ул. Гагарина, 8', 'Завершена', const Color(0xFF22C55E)),
-      _InspectionRow('#144', 'Сидоров Д.В.', 'ул. Пушкина, 3', 'Отклонена', const Color(0xFFEF4444)),
-      _InspectionRow('#143', 'Сидоров Д.В.', 'пр. Невский, 100', 'Завершена', const Color(0xFF22C55E)),
-    ];
-
-    return Column(
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-          child: Row(
-            children: [
-              const Text('Все инспекции', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, color: Color(0xFF334155))),
-              const Spacer(),
-              Text('${inspections.length} записей', style: const TextStyle(fontSize: 12, color: Color(0xFF94A3B8))),
-            ],
+  Widget _inspectionCard(AdminInspection i) {
+    final statusInfo = _statusUi(i.statusSync);
+    final inspectorShort = _shortName(i.engineer?.fullName ?? '');
+    final shortId = '#${i.id.length > 6 ? i.id.substring(i.id.length - 6) : i.id}';
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(10),
+        boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.03), blurRadius: 4, offset: const Offset(0, 1))],
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(color: const Color(0xFFF1F5F9), borderRadius: BorderRadius.circular(8)),
+            child: const Icon(Icons.camera_alt, color: Color(0xFF94A3B8), size: 20),
           ),
-        ),
-        Expanded(
-          child: ListView.builder(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            itemCount: inspections.length,
-            itemBuilder: (context, index) {
-              final i = inspections[index];
-              return Container(
-                margin: const EdgeInsets.only(bottom: 8),
-                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(10),
-                  boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.03), blurRadius: 4, offset: const Offset(0, 1))],
-                ),
-                child: Row(
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
                   children: [
+                    Text('Инспекция $shortId', style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: Color(0xFF334155))),
+                    const SizedBox(width: 8),
                     Container(
-                      width: 40,
-                      height: 40,
-                      decoration: BoxDecoration(
-                        color: const Color(0xFFF1F5F9),
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: const Icon(Icons.camera_alt, color: Color(0xFF94A3B8), size: 20),
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                      decoration: BoxDecoration(color: statusInfo.color.withOpacity(0.1), borderRadius: BorderRadius.circular(6)),
+                      child: Text(statusInfo.label, style: TextStyle(fontSize: 11, fontWeight: FontWeight.w500, color: statusInfo.color)),
                     ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            children: [
-                              Text('Инспекция ${i.id}', style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: Color(0xFF334155))),
-                              const SizedBox(width: 8),
-                              Container(
-                                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-                                decoration: BoxDecoration(
-                                  color: i.statusColor.withOpacity(0.1),
-                                  borderRadius: BorderRadius.circular(6),
-                                ),
-                                child: Text(i.status, style: TextStyle(fontSize: 11, fontWeight: FontWeight.w500, color: i.statusColor)),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 4),
-                          Text('${i.inspector} \u2022 ${i.address}', style: const TextStyle(fontSize: 12, color: Color(0xFF64748B))),
-                        ],
-                      ),
-                    ),
-                    const Icon(Icons.chevron_right, color: Color(0xFF94A3B8), size: 20),
                   ],
                 ),
-              );
-            },
+                const SizedBox(height: 4),
+                Text('$inspectorShort • ${i.address}', style: const TextStyle(fontSize: 12, color: Color(0xFF64748B))),
+              ],
+            ),
           ),
+          const Icon(Icons.chevron_right, color: Color(0xFF94A3B8), size: 20),
+        ],
+      ),
+    );
+  }
+
+  String _shortName(String full) {
+    final parts = full.split(' ').where((w) => w.isNotEmpty).toList();
+    if (parts.isEmpty) return '—';
+    if (parts.length == 1) return parts.first;
+    final initials = parts.skip(1).map((w) => '${w[0]}.').join('');
+    return '${parts.first} $initials';
+  }
+
+  ({String label, Color color}) _statusUi(String status) {
+    switch (status) {
+      case 'save':
+      case 'synced':
+        return (label: 'Завершена', color: const Color(0xFF22C55E));
+      case 'pending':
+        return (label: 'На проверке', color: const Color(0xFFF59E0B));
+      case 'rejected':
+        return (label: 'Отклонена', color: const Color(0xFFEF4444));
+      default:
+        return (label: status, color: const Color(0xFF94A3B8));
+    }
+  }
+
+  // --- Кнопка «Загрузить ещё» ---
+  Widget _buildLoadMore(bool hasMore, bool loading, String? error, VoidCallback onLoad) {
+    if (error != null) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: Column(
+          children: [
+            Text(error, style: const TextStyle(fontSize: 13, color: Color(0xFFEF4444))),
+            const SizedBox(height: 8),
+            OutlinedButton(onPressed: onLoad, child: const Text('Повторить')),
+          ],
         ),
-      ],
+      );
+    }
+    if (!hasMore) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 16),
+        child: Center(child: Text('Больше нет записей', style: TextStyle(fontSize: 12, color: Color(0xFF94A3B8)))),
+      );
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      child: SizedBox(
+        width: double.infinity,
+        height: 40,
+        child: OutlinedButton(
+          style: OutlinedButton.styleFrom(
+            foregroundColor: _teal,
+            side: const BorderSide(color: _teal),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+          ),
+          onPressed: loading ? null : onLoad,
+          child: loading
+              ? const SizedBox(width: 18, height: 18, child: CircularProgressIndicator(strokeWidth: 2, color: _teal))
+              : const Text('Загрузить ещё', style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600)),
+        ),
+      ),
+    );
+  }
+
+  Widget _errorView(String message, VoidCallback onRetry) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline, color: Color(0xFFEF4444), size: 48),
+            const SizedBox(height: 12),
+            Text(message, textAlign: TextAlign.center, style: const TextStyle(fontSize: 14, color: Color(0xFF334155))),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(backgroundColor: _teal, foregroundColor: Colors.white),
+              onPressed: onRetry,
+              child: const Text('Повторить'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 
@@ -424,7 +691,6 @@ class _AdminMainScreenState extends State<AdminMainScreen> {
             _settingsItem(Icons.security, 'Двухфакторная аутентификация', 'Выключена'),
           ]),
           const SizedBox(height: 24),
-          // кнопка выхода
           SizedBox(
             width: double.infinity,
             height: 44,
@@ -435,10 +701,7 @@ class _AdminMainScreenState extends State<AdminMainScreen> {
                 shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
               ),
               onPressed: () {
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(builder: (_) => const LoginScreen()),
-                );
+                Navigator.pushReplacement(context, MaterialPageRoute(builder: (_) => const LoginScreen()));
               },
               icon: const Icon(Icons.logout, size: 18),
               label: const Text('Выйти из аккаунта', style: TextStyle(fontSize: 14)),
@@ -475,8 +738,7 @@ class _AdminMainScreenState extends State<AdminMainScreen> {
           Icon(icon, size: 20, color: _teal),
           const SizedBox(width: 12),
           Expanded(child: Text(title, style: const TextStyle(fontSize: 14, color: Color(0xFF334155)))),
-          if (value.isNotEmpty)
-            Text(value, style: const TextStyle(fontSize: 13, color: Color(0xFF94A3B8))),
+          if (value.isNotEmpty) Text(value, style: const TextStyle(fontSize: 13, color: Color(0xFF94A3B8))),
           const SizedBox(width: 4),
           const Icon(Icons.chevron_right, size: 18, color: Color(0xFF94A3B8)),
         ],
@@ -485,19 +747,6 @@ class _AdminMainScreenState extends State<AdminMainScreen> {
   }
 }
 
-class _UserRow {
-  final String name;
-  final String email;
-  final String role;
-  final bool active;
-  _UserRow(this.name, this.email, this.role, this.active);
-}
-
-class _InspectionRow {
-  final String id;
-  final String inspector;
-  final String address;
-  final String status;
-  final Color statusColor;
-  _InspectionRow(this.id, this.inspector, this.address, this.status, this.statusColor);
-}
+// Используется только как placeholder для intl-форматтера дат, если понадобится.
+// ignore: unused_element
+String _formatTs(DateTime dt) => DateFormat('dd.MM.yyyy HH:mm').format(dt);

--- a/drain_eye/lib/presentation/screens/auth/login_screen.dart
+++ b/drain_eye/lib/presentation/screens/auth/login_screen.dart
@@ -73,10 +73,12 @@ class _LoginScreenState extends State<LoginScreen> {
     return BlocListener<AuthBloc, AuthState>(
       listener: (context, state) {
         if (state is AuthAuthenticated) {
-          // успешный вход — переход на главный экран
+          final isAdmin = state.user.role == 'admin';
           Navigator.pushReplacement(
             context,
-            MaterialPageRoute(builder: (_) => const MainScreen()),
+            MaterialPageRoute(
+              builder: (_) => isAdmin ? const AdminMainScreen() : const MainScreen(),
+            ),
           );
         }
         if (state is AuthError) {


### PR DESCRIPTION
## Что сделано

Реализован сценарий **«Администратор просматривает главную страницу административной панели»**: после входа администратор видит сводку метрик и список последних инспекций.

## Изменения на главной странице админки

### Раздел «Обзор системы»
- Карточки: **Инспекторов**, **Инспекций**, **За сегодня**.

### Раздел «Последние инспекции» (новый)
- Фиксированно последние **4 инспекции** через `getInspections(limit: 4)`.
- Каждая запись: аватар с инициалом, ФИО инспектора, идентификатор инспекции (`#xxxxxx`), относительное время.
- Хелпер `_relativeTime()` с правильным склонением: «10 мин назад», «2 часа назад», «3 дня назад», «01.05.2026» для записей старше недели.
- Состояния загрузки / ошибки / пустого списка оформлены в стиле существующих карточек.

### Pull-to-refresh
- Свайп вниз одновременно перезагружает метрики и список последних инспекций (`_loadMetrics()` + `_loadRecentInspections()` параллельно).